### PR TITLE
Add flag to choose output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ This will generate a high-level JSON report with test counts and duration in mil
 }
 ```
 
+### Report output path
+
+You can choose where the report will be generated, otherwise the default is `test-timings-[timestamp]`.
+
+```
+npx ember-test-audit --output report.txt
+```
+
 ## :warning: Alpha software
 
 This worked for my test suite, but it hasn't exactly been battle-hardened yet.

--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ const { argv } = require('yargs')
     type: 'boolean',
     description: 'generate report as JSON instead of text',
   })
+  .option('output', {
+    alias: 'o',
+    description: 'what path to write the report to',
+  })
   .help();
 
 function run() {
@@ -58,10 +62,11 @@ function run() {
       json.forEach(addMetadata);
       const aggregation = aggregateTimings(json);
       const output = argv.json ? JSON.stringify(statsFor(aggregation.all), null, 2) : getComplete(aggregation);
-      fs.writeFileSync(`./test-timings-${ts}`, output);
+      const path = argv.output || `./test-timings-${ts}`;
+      fs.writeFileSync(path, output);
       printSummary(aggregation);
       log('');
-      log(chalk.bold(`Full audit written to file ./test-timings-${ts}`));
+      log(chalk.bold(`Full audit written to file ${path}`));
     })
     .catch(err => {
       log('Bad exit: ', err);


### PR DESCRIPTION
Sorry to be back again so soon, I just realised that it would simplify the preparations for using [the comparison action](https://github.com/backspace/ember-test-audit-comparison-action) somewhat to be able to choose the path for the report vs having an auto-generated filename. Then things like [this line](https://github.com/hashicorp/nomad/blob/57ba55062191696b017bb75a6ad7d0867cdca2e1/.github/workflows/ember-test-audit.yml#L29) become unnecessary.

I dithered about the best name for the flag but `-o` something I’ve seen from other tools, so I used that or `--output`.